### PR TITLE
Fix error when using credit card in multiplayer

### DIFF
--- a/src/main/java/sk/dipo/moneymod/network/packet/server/AtmLoginMsg.java
+++ b/src/main/java/sk/dipo/moneymod/network/packet/server/AtmLoginMsg.java
@@ -29,11 +29,11 @@ public class AtmLoginMsg {
 
     public void encode(PacketBuffer buffer) {
         buffer.writeEnumValue(hand);
-        buffer.writeString(pinCode);
+        buffer.writeString(pinCode, 128);
     }
 
     public static AtmLoginMsg decode(PacketBuffer buffer) {
-        return new AtmLoginMsg(buffer.readEnumValue(Hand.class), buffer.readString());
+        return new AtmLoginMsg(buffer.readEnumValue(Hand.class), buffer.readString(128));
     }
 
     public void handle(Supplier<NetworkEvent.Context> ctx) {

--- a/src/main/java/sk/dipo/moneymod/network/packet/server/AtmSignCardMsg.java
+++ b/src/main/java/sk/dipo/moneymod/network/packet/server/AtmSignCardMsg.java
@@ -27,11 +27,11 @@ public class AtmSignCardMsg {
 
     public void encode(PacketBuffer buffer) {
         buffer.writeEnumValue(hand);
-        buffer.writeString(pinCode);
+        buffer.writeString(pinCode, 128);
     }
 
     public static AtmSignCardMsg decode(PacketBuffer buffer) {
-        return new AtmSignCardMsg(buffer.readEnumValue(Hand.class), buffer.readString());
+        return new AtmSignCardMsg(buffer.readEnumValue(Hand.class), buffer.readString(128));
     }
 
     public void handle(Supplier<NetworkEvent.Context> ctx) {


### PR DESCRIPTION
I noticed an error message when trying to use the credit card in multiplayer, and i found out that you have to use the PacketBuffer::writeString(string, maxLength) method instead of the PacketBuffer::writeString(string) method. I used 128 as the maximum string length, even though i assume you could also just use 4, as a pin code shouldn't be more than that. But i left it like this to be safe.